### PR TITLE
Make sure to use the latest version of Ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ services:
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo add-apt-repository --yes --update ppa:ansible/ansible
   - sudo apt-get update
-  - sudo apt-get -y install docker-ce
+  - sudo apt-get -y install docker-ce ansible
+  - ansible --version
+  - docker version
 install:
   - pip install molecule docker
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo add-apt-repository --yes --update ppa:ansible/ansible
+  - sudo add-apt-repository --yes ppa:ansible/ansible
   - sudo apt-get update
   - sudo apt-get -y install docker-ce ansible
   - ansible --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_install:
   - ansible --version
   - docker version
 install:
-  - pip install molecule docker
+  - pip install ansible-lint molecule docker
 script:
   - molecule test


### PR DESCRIPTION
We currently have a quality score of 2.5, because of linting errors that Travis didn't catch.

Let's see if upgrading to a newer version of Ansible helps find these errors in Travis.