### PR TITLE
Actually set up a Kubernetes cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@
 sudo: required
 language: python
 cache: pip
-services:
-  - docker
 before_install:
+  - swapoff -a
+  - cat ci/daemon.json | sudo tee /etc/docker/daemon.json
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo add-apt-repository --yes ppa:ansible/ansible

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@
 sudo: required
 language: python
 cache: pip
+
+env:
+  matrix:
+    - MOLECULE_DISTRO: ubuntu1804
+    - MOLECULE_DISTRO: ubuntu1604
+
 before_install:
   - swapoff -a
   - cat ci/daemon.json | sudo tee /etc/docker/daemon.json

--- a/ci/daemon.json
+++ b/ci/daemon.json
@@ -1,0 +1,1 @@
+{"exec-opts": ["native.cgroupdriver=cgroupfs"]}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ load_kernel_modules: true
 # and https://github.com/coreos/flannel/pull/1045
 # We can reset this to v0.11.0 once this is fixed.
 flannel_version: bc79dd1505b0c8681ece4de4c0d86c5cd2643275
+
+kubernetes_ignore_preflight_errors: ""
+kubernetes_kubeadm_init_extra_opts: ""

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,16 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: bionic
-    image: geerlingguy/docker-ubuntu1804-ansible:latest
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      - /var/lib/docker
-    pre_build_image: true
-    command: ""
-  - name: xenial
-    image: geerlingguy/docker-ubuntu1604-ansible:latest
+  - name: ${MOLECULE_DISTRO:-ubuntu1804}
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,6 +13,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /var/lib/docker
     pre_build_image: true
+    command: ""
   - name: xenial
     image: geerlingguy/docker-ubuntu1604-ansible:latest
     privileged: true
@@ -20,6 +21,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /var/lib/docker
     pre_build_image: true
+    command: ""
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -5,5 +5,9 @@
     - load_kernel_modules: false
     - preseed_docker_images: false
     - device_farm_role: master
+    - kubernetes_ignore_preflight_errors:
+        "Service-Docker,\
+        SystemVerification,\
+        FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
   roles:
     - role: ansible-device-cloud-node

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,5 +4,6 @@
   vars:
     - load_kernel_modules: false
     - preseed_docker_images: false
+    - device_farm_role: master
   roles:
     - role: ansible-device-cloud-node

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,5 +42,7 @@
     when:
       - device_farm_role is defined
       - device_farm_role == 'master'
+      - kubernetes_init_stat.stat is defined
+      - not kubernetes_init_stat.stat.exists
 
   become: true

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -11,6 +11,8 @@
     --token {{ kubeadm_token }}
     --kubernetes-version v{{ kubernetes_version }}
     --apiserver-cert-extra-sans={{ inventory_hostname }}
+    --ignore-preflight-errors={{ kubernetes_ignore_preflight_errors }}
+    {{ kubernetes_kubeadm_init_extra_opts }}
   when: not kubernetes_init_stat.stat.exists
 
 - name: Remove the Kubernetes configuration directory

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -27,6 +27,7 @@
       kubeadm init failed to set up the cluster.
       Additional information information may be available in the kubelet logs:
       {{ kubelet_logs.stdout }}
+  name: Fail when kubeadm init fails
   when: not kubernetes_init_stat.stat.exists and kubeadm_init.failed
 
 - name: Remove the Kubernetes configuration directory
@@ -34,22 +35,26 @@
     path=~/.kube
     state=absent
   become: false
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Create the Kubernetes configuration directory
   file:
     path=~/.kube
     state=directory
   become: false
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Copy the Kubernetes configuration files
   shell: |
     sudo cp -i /etc/kubernetes/admin.conf ~/.kube/config
   become: false
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Fix permissions on the Kubernetes configuration file
   shell: |
     sudo chown $(id -u):$(id -g) ~/.kube/config
   become: false
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Copy the Kubernetes configuration file
   fetch:
@@ -62,12 +67,15 @@
     kubectl
     apply -f https://raw.githubusercontent.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml
   become: false
+  when: not kubernetes_init_stat.stat.exists
 
   # Only taint the master node if no worker nodes exist.
 - name: Tainting the master node
   shell: kubectl taint nodes --all node-role.kubernetes.io/master-
   become: false
-  when: "not kubernetes_init_stat.stat.exists and ('device-farm-workers' not in groups or groups['device-farm-workers'] | length == 0)"
+  when: >-
+    not kubernetes_init_stat.stat.exists
+    and ('device-farm-workers' not in groups or groups['device-farm-workers'] | length == 0)
 
 - name: Configure Helm service account YAML configuration
   copy:
@@ -107,7 +115,9 @@
 - name: Initializing Helm
   command: helm init --service-account helm
   become: false
+  when: not helm_exists.stat.exists
 
 - name: Waiting for Helm to become available
   command: kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system
   become: false
+  when: not helm_exists.stat.exists

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -14,6 +14,20 @@
     --ignore-preflight-errors={{ kubernetes_ignore_preflight_errors }}
     {{ kubernetes_kubeadm_init_extra_opts }}
   when: not kubernetes_init_stat.stat.exists
+  ignore_errors: true
+  register: kubeadm_init
+
+- name: Get kubelet logs
+  shell: journalctl -u kubelet
+  when: not kubernetes_init_stat.stat.exists and kubeadm_init.failed
+  register: kubelet_logs
+
+- fail:
+    msg: |
+      kubeadm init failed to set up the cluster.
+      Additional information information may be available in the kubelet logs:
+      {{ kubelet_logs.stdout }}
+  when: not kubernetes_init_stat.stat.exists and kubeadm_init.failed
 
 - name: Remove the Kubernetes configuration directory
   file:

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -60,8 +60,7 @@
 - name: Configure networking
   shell: >-
     kubectl
-    apply
-    -f https://raw.githubusercontent.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml
+    apply -f https://raw.githubusercontent.com/coreos/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml
   become: false
 
   # Only taint the master node if no worker nodes exist.

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -67,7 +67,7 @@
 - name: Tainting the master node
   shell: kubectl taint nodes --all node-role.kubernetes.io/master-
   become: false
-  when: "'device-farm-workers' not in groups or groups['device-farm-workers'] | length == 0"
+  when: "not kubernetes_init_stat.stat.exists and ('device-farm-workers' not in groups or groups['device-farm-workers'] | length == 0)"
 
 - name: Configure Helm service account YAML configuration
   copy:


### PR DESCRIPTION
- Make sure there is no swap on the host (call `swapoff -a`), so the container (and kubelet) doesn't see any swap in `/proc/swaps`.
- Make sure the Docker daemon is configured properly
- Set `device_farm_role` to `master` so a Kubernetes cluster is initialized
- Better error messages when `kubeadm init` fails.
- Don't remove the taint on master when the cluster already exists