### PR TITLE
Re-enable ANSIBLE0012 rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install:
   - pip install ansible-lint molecule docker
   - ansible-lint --version
 script:
-  - ansible-lint  -x ANSIBLE0012 -x ANSIBLE0013 -x ANSIBLE0016 -x 405 .
+  - ansible-lint -x ANSIBLE0013 -x ANSIBLE0016 -x 405 .
   - molecule test

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,7 +20,6 @@ provisioner:
     name: ansible-lint
     options:
       x:
-        - ANSIBLE0012  # Commands should not change things if nothing needs doing.
         - ANSIBLE0013  # Use shell only when shell functionality is required
         - ANSIBLE0016
         - 405  # Remote package tasks should have a retry

--- a/tasks/cluster-ready.yml
+++ b/tasks/cluster-ready.yml
@@ -7,3 +7,8 @@
   delay: 1
   retries: 100
   become: false
+  when:
+    - device_farm_role is defined
+    - device_farm_role == 'master'
+    - kubernetes_init_stat.stat is defined
+    - not kubernetes_init_stat.stat.exists


### PR DESCRIPTION
Move the conditional for including the `master.yml` file to the tasks inside that file to suppress the warning.