### PR TITLE
Check system requirements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,12 @@ flannel_version: bc79dd1505b0c8681ece4de4c0d86c5cd2643275
 kubernetes_ignore_preflight_errors: ""
 kubernetes_kubeadm_init_extra_opts: ""
 
+# Standard system requirements for Kubernetes
+# Memory is actually in MiB instead of MB (because /proc/meminfo used KiB),
+# and 4 GB = 3814 MiB
+kubernetes_required_memory: 3814
+kubernetes_required_vcpus: 2
+
 gitlab_runner_package: "gitlab-runner"
 gitlab_runner_gpg: "https://packages.gitlab.com/gpg.key"
 gitlab_runner_repo: "deb https://packages.gitlab.com/runner/{{ gitlab_runner_package }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main"

--- a/tasks/kubernetes.yml
+++ b/tasks/kubernetes.yml
@@ -1,4 +1,13 @@
 ---
+- name: Print system configuration
+  debug:
+    msg: "System {{ inventory_hostname }} has {{ ansible_memory_mb.real.total }} of memory, and {{ ansible_processor_vcpus }} vCPUs"
+
+- name: Check system requirements
+  assert:
+    that:
+      - ansible_memory_mb.real.total >= {{ kubernetes_required_memory }}
+      - ansible_processor_vcpus >= {{ kubernetes_required_vcpus }}
 
 - name: Add the required apt packages
   apt:

--- a/tasks/kubernetes.yml
+++ b/tasks/kubernetes.yml
@@ -1,7 +1,9 @@
 ---
 - name: Print system configuration
   debug:
-    msg: "System {{ inventory_hostname }} has {{ ansible_memory_mb.real.total }} of memory, and {{ ansible_processor_vcpus }} vCPUs"
+    msg: |
+      System {{ inventory_hostname }} has {{ ansible_memory_mb.real.total }}
+      of memory, and {{ ansible_processor_vcpus }} vCPUs
 
 - name: Check system requirements
   assert:


### PR DESCRIPTION
Make sure there are at least 2 vCPUs and there is 4 GB of RAM on the target machine.

Detected when running the playbook on a vanilla Vagrant instance with 1 GB of RAM. In such a scenario, `kubeadm init` will time out because there's too much swapping going on.