### PR TITLE
Disable swap

### DIFF
--- a/molecule/vm-reboot/INSTALL.rst
+++ b/molecule/vm-reboot/INSTALL.rst
@@ -1,0 +1,17 @@
+*******
+Vagrant driver installation guide
+*******
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+* python-vagrant
+
+Install
+=======
+
+.. code-block:: bash
+
+    $ sudo pip install python-vagrant

--- a/molecule/vm-reboot/molecule.yml
+++ b/molecule/vm-reboot/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    box: bento/ubuntu-18.04
+    # The roles will check for 4096 MB (4 GB), but
+    # 4 GB in VirtualBox is actually a bit less for the VM,
+    # as some memory is also consumed by the graphics card,... .
+    # So give 4200 MB.
+    memory: 4200
+    cpus: 2
+provisioner:
+  name: ansible
+  playbooks:
+    side_effect: side_effect.yml
+  lint:
+    name: ansible-lint
+scenario:
+  name: vm-reboot
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/vm-reboot/playbook.yml
+++ b/molecule/vm-reboot/playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    - device_farm_role: master
+    # Preseeding of Docker images is currently not idempotent
+    - preseed_docker_images: false
+  roles:
+    - role: ansible-device-cloud-node

--- a/molecule/vm-reboot/prepare.yml
+++ b/molecule/vm-reboot/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: true
+      changed_when: false

--- a/molecule/vm-reboot/side_effect.yml
+++ b/molecule/vm-reboot/side_effect.yml
@@ -1,0 +1,13 @@
+---
+- name: Side-Effects
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Reboot the server and wait for it to come back up.
+      reboot:
+      become: true
+
+    # Pause to give Kubernetes time to start up
+    - name: Pausing to allow Kubernetes to start
+      pause:
+        seconds: 45

--- a/molecule/vm-reboot/tests/test_default.py
+++ b/molecule/vm-reboot/tests/test_default.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_no_swap_in_fstab(host):
+    fstab = host.file("/etc/fstab")
+    assert not fstab.contains("swap")
+
+
+# Make sure /proc/swaps contains one line at most (the header),
+# and no content like 'file' which would indicate content like this:
+# Filename				Type		Size	Used	Priority
+# /swapfile                               file		2097148	1631232	-2
+def test_no_swaps_in_proc(host):
+    swaps = host.file("/proc/swaps")
+    assert len(swaps.content_string.split('\n')) < 2
+    assert not swaps.contains("file")
+    assert not swaps.contains("partition")
+
+
+# The goal of these tests are to make sure that the Kubernetes cluster
+# is still up and running _after_ a reboot.
+# The main process which can die is kubelet, which goes in a crash
+# loop when, say, swap is enabled (and the playbooks disabled swap
+# in a non-presisent manner).
+@pytest.mark.parametrize('name', [
+    'docker',
+    'kubelet'
+])
+def test_service_is_running(host, name):
+    service = host.service(name)
+
+    assert service.is_running
+
+
+# It never hurts to run some other commands, too.
+# Running kubectl get pods will make sure the API server is
+# up and running.
+# These commands will only be successful once Kubernetes is
+# up and running, so there's a delay in the side_effect playbook
+# to allow for Kubernetes to start once the VM has rebooted.
+def test_kubectl_get_pods_works(host):
+    host.run_expect([0], "kubectl get pods -n kube-system")
+
+
+def test_kubectl_version_works(host):
+    host.run_expect([0], "kubectl version")
+
+
+def test_helm_version_works(host):
+    host.run_expect([0], "helm version")
+
+
+def test_helm_list_works(host):
+    host.run_expect([0], "helm list")

--- a/tasks/kubernetes.yml
+++ b/tasks/kubernetes.yml
@@ -11,6 +11,19 @@
       - ansible_memory_mb.real.total >= {{ kubernetes_required_memory }}
       - ansible_processor_vcpus >= {{ kubernetes_required_vcpus }}
 
+# Disable swap; Kubernetes doesn't run with swap enabled
+# Debug
+- name: Remove swap from /etc/fstab (Ubuntu)
+  mount:
+    path: none
+    fstype: swap
+    state: absent
+  when: ansible_distribution == "Ubuntu"
+
+- name: Disable swap
+  command: swapoff -a
+  when: ansible_swaptotal_mb > 0
+
 - name: Add the required apt packages
   apt:
     pkg:


### PR DESCRIPTION
Make sure to call both swapoff and remove the swap file from /etc/fstab.
Add a Vagrant-based test which applies the role, reboots the VM
and makes sure swap is off and Kubernetes still works.