### PR TITLE
Make the join command accept extra arguments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ flannel_version: bc79dd1505b0c8681ece4de4c0d86c5cd2643275
 kubernetes_ignore_preflight_errors: ""
 kubernetes_kubeadm_init_extra_opts: ""
 kubernetes_kubeadm_join_extra_opts: ""
+kubernetes_apiserver_advertise_address: ""
 
 # Standard system requirements for Kubernetes
 # Memory is actually in MiB instead of MB (because /proc/meminfo used KiB),

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ flannel_version: bc79dd1505b0c8681ece4de4c0d86c5cd2643275
 
 kubernetes_ignore_preflight_errors: ""
 kubernetes_kubeadm_init_extra_opts: ""
+kubernetes_kubeadm_join_extra_opts: ""
 
 # Standard system requirements for Kubernetes
 # Memory is actually in MiB instead of MB (because /proc/meminfo used KiB),

--- a/molecule/two-node-cluster/molecule.yml
+++ b/molecule/two-node-cluster/molecule.yml
@@ -1,0 +1,34 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+platforms:
+  - name: node-master
+    box: bento/ubuntu-18.04
+    memory: 2048
+    cpus: 2
+  - name: node-worker
+    box: bento/ubuntu-18.04
+    memory: 2048
+    cpus: 2
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      node-master:
+        device_farm_role: master
+      node-worker:
+        device_farm_role: worker
+  lint:
+    name: ansible-lint
+scenario:
+  name: two-node-cluster
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/two-node-cluster/molecule.yml
+++ b/molecule/two-node-cluster/molecule.yml
@@ -12,16 +12,25 @@ platforms:
     box: bento/ubuntu-18.04
     memory: 2048
     cpus: 2
+    interfaces:
+      - auto_config: true
+        ip: "192.168.200.2"
+        network_name: private_network
   - name: node-worker
     box: bento/ubuntu-18.04
     memory: 2048
     cpus: 2
+    interfaces:
+      - auto_config: true
+        ip: "192.168.200.3"
+        network_name: private_network
 provisioner:
   name: ansible
   inventory:
     host_vars:
       node-master:
         device_farm_role: master
+        kubernetes_apiserver_advertise_address: "192.168.200.2"
       node-worker:
         device_farm_role: worker
   lint:

--- a/molecule/two-node-cluster/playbook.yml
+++ b/molecule/two-node-cluster/playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    - kubernetes_required_memory: 1000
+    # Preseeding of Docker images is currently not idempotent
+    - preseed_docker_images: false
+  roles:
+    - role: ansible-device-cloud-node

--- a/molecule/two-node-cluster/prepare.yml
+++ b/molecule/two-node-cluster/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: true
+      changed_when: false

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -13,7 +13,7 @@
       --kubernetes-version v{{ kubernetes_version }}
       --apiserver-cert-extra-sans {{ inventory_hostname }}
       {% if kubernetes_apiserver_advertise_address %}
-      --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address}}
+      --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address }}
       {% endif %}
       {% if kubernetes_ignore_preflight_errors %}
       --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }}

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -4,14 +4,28 @@
     path: /etc/kubernetes/admin.conf
   register: kubernetes_init_stat
 
+- name: Print kubeadm init command
+  debug:
+    msg: >-
+      kubeadm init
+      --pod-network-cidr {{ pod_network }}
+      --token {{ kubeadm_token }}
+      --kubernetes-version v{{ kubernetes_version }}
+      --apiserver-cert-extra-sans {{ inventory_hostname }}
+      {% if kubernetes_apiserver_advertise_address %} --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address}} {% endif %}
+      {% if kubernetes_ignore_preflight_errors %} --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }} {% endif %}
+      {{ kubernetes_kubeadm_init_extra_opts }}
+  when: not kubernetes_init_stat.stat.exists
+
 - name: Run kubeadm init
   command: >-
     kubeadm init
-    --pod-network-cidr={{ pod_network }}
+    --pod-network-cidr {{ pod_network }}
     --token {{ kubeadm_token }}
     --kubernetes-version v{{ kubernetes_version }}
-    --apiserver-cert-extra-sans={{ inventory_hostname }}
-    --ignore-preflight-errors={{ kubernetes_ignore_preflight_errors }}
+    --apiserver-cert-extra-sans {{ inventory_hostname }}
+    {% if kubernetes_apiserver_advertise_address %} --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address}} {% endif %}
+    {% if kubernetes_ignore_preflight_errors %} --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }} {% endif %}
     {{ kubernetes_kubeadm_init_extra_opts }}
   when: not kubernetes_init_stat.stat.exists
   ignore_errors: true

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -12,8 +12,12 @@
       --token {{ kubeadm_token }}
       --kubernetes-version v{{ kubernetes_version }}
       --apiserver-cert-extra-sans {{ inventory_hostname }}
-      {% if kubernetes_apiserver_advertise_address %} --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address}} {% endif %}
-      {% if kubernetes_ignore_preflight_errors %} --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }} {% endif %}
+      {% if kubernetes_apiserver_advertise_address %}
+      --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address}}
+      {% endif %}
+      {% if kubernetes_ignore_preflight_errors %}
+      --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }}
+      {% endif %}
       {{ kubernetes_kubeadm_init_extra_opts }}
   when: not kubernetes_init_stat.stat.exists
 
@@ -24,8 +28,12 @@
     --token {{ kubeadm_token }}
     --kubernetes-version v{{ kubernetes_version }}
     --apiserver-cert-extra-sans {{ inventory_hostname }}
-    {% if kubernetes_apiserver_advertise_address %} --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address}} {% endif %}
-    {% if kubernetes_ignore_preflight_errors %} --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }} {% endif %}
+    {% if kubernetes_apiserver_advertise_address %}
+    --apiserver-advertise-address {{ kubernetes_apiserver_advertise_address }}
+    {% endif %}
+    {% if kubernetes_ignore_preflight_errors %}
+    --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }}
+    {% endif %}
     {{ kubernetes_kubeadm_init_extra_opts }}
   when: not kubernetes_init_stat.stat.exists
   ignore_errors: true

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -3,6 +3,8 @@
 - name: Join node to the Kubernetes cluster
   command: >
     {{ kubeadm_join_command }}
-    {% if kubernetes_ignore_preflight_errors %} --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }} {% endif %}
+    {% if kubernetes_ignore_preflight_errors %}
+    --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }}
+    {% endif %}
     {{ kubernetes_kubeadm_join_extra_opts }}
     creates=/etc/kubernetes/kubelet.conf

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -3,4 +3,6 @@
 - name: Join node to the Kubernetes cluster
   command: >
     {{ kubeadm_join_command }}
+    --ignore-preflight-errors={{ kubernetes_ignore_preflight_errors }}
+    {{ kubernetes_kubeadm_join_extra_opts }}
     creates=/etc/kubernetes/kubelet.conf

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -3,6 +3,6 @@
 - name: Join node to the Kubernetes cluster
   command: >
     {{ kubeadm_join_command }}
-    --ignore-preflight-errors={{ kubernetes_ignore_preflight_errors }}
+    {% if kubernetes_ignore_preflight_errors %} --ignore-preflight-errors {{ kubernetes_ignore_preflight_errors }} {% endif %}
     {{ kubernetes_kubeadm_join_extra_opts }}
     creates=/etc/kubernetes/kubelet.conf


### PR DESCRIPTION
The values for `--ignore-preflight-errors` are now passed to the join command as well, and you can also pass extra options if you want.

Also adds a (WIP) scenario for testing a two-node cluster in a Vagrant config.