### PR TITLE
Various reliability fixes

### DIFF
--- a/tasks/kubernetes.yml
+++ b/tasks/kubernetes.yml
@@ -34,6 +34,8 @@
   when:
     - ansible_swaptotal_mb is defined
     - ansible_swaptotal_mb > 0
+  # This fails when running inside Docker/LXD containers.
+  ignore_errors: true
 
 - name: Add the required apt packages
   apt:

--- a/tasks/worker.yml
+++ b/tasks/worker.yml
@@ -1,4 +1,8 @@
 ---
+- name: Check whether Kubernetes has already been initialized.
+  stat:
+    path: /etc/kubernetes/admin.conf
+  register: kubernetes_init_stat
 
 - name: Join node to the Kubernetes cluster
   command: >
@@ -8,3 +12,6 @@
     {% endif %}
     {{ kubernetes_kubeadm_join_extra_opts }}
     creates=/etc/kubernetes/kubelet.conf
+  when:
+    - not kubernetes_init_stat.stat.exists
+    - kubeadm_join_command is defined


### PR DESCRIPTION
- Don't  fail when swapoff fails (this can happen in containers)
- Don't attempt to join the cluster when the worker node is already configured.