### PR TITLE
Upgrade to Flannel v0.11.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ kubernetes_version: 1.12.1
 docker_version: 18.06.0~ce~3-0~ubuntu
 helm_version: v2.11.0
 pod_network: 10.244.0.0/16
+flannel_version: v0.11.0
 kubeadm_token: a64b93.7ce2f940e0961d56
 
 # By default, use kubeadm to preseed the docker images used by Kubernetes
@@ -13,12 +14,6 @@ preseed_docker_images: true
 # By default, load the ip_vs_* kernel modules. These may not exist as proper
 # modules on some kernel configurations (e.g. Azure).
 load_kernel_modules: true
-
-# Flannel v0.10.0 doesn't work properly with Kubernetes 1.12+, see
-# https://github.com/coreos/flannel/issues/1044#issuecomment-425519107
-# and https://github.com/coreos/flannel/pull/1045
-# We can reset this to v0.11.0 once this is fixed.
-flannel_version: bc79dd1505b0c8681ece4de4c0d86c5cd2643275
 
 kubernetes_ignore_preflight_errors: ""
 kubernetes_kubeadm_init_extra_opts: ""


### PR DESCRIPTION
Because of https://github.com/coreos/flannel/issues/1044#issuecomment-425519107, we were stuck with an intermediate version of flannel. v0.11.0 has been released, so it's time to upgrade!