### PR TITLE
Update to Docker 18.06.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kubernetes_version: 1.12.1
-docker_version: 18.06.0~ce~3-0~ubuntu
+docker_version: 18.06.2~ce~3-0~ubuntu
 helm_version: v2.12.3
 pod_network: 10.244.0.0/16
 flannel_version: v0.11.0

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
   ('kubelet', '1.12.1'),
   ('kubeadm', '1.12.1'),
   ('kubectl', '1.12.1'),
-  ('docker-ce', '18.06.0'),
+  ('docker-ce', '18.06.2'),
   ('gitlab-runner', '11.7'),
   ('i965-va-driver', {'xenial': '1.7.0', 'bionic': '2.1.0'})
 ])


### PR DESCRIPTION
This version of Docker fixes a runc vulnerability (CVE-2019-5736)

See https://docs.docker.com/engine/release-notes/#18062