### PR TITLE
Update to Kubernetes v1.12.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: 1.12.1
+kubernetes_version: 1.12.5
 docker_version: 18.06.2~ce~3-0~ubuntu
 helm_version: v2.12.3
 pod_network: 10.244.0.0/16

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -9,9 +9,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 # These packages must be installed, and at the correct version
 @pytest.mark.parametrize('name,version', [
-  ('kubelet', '1.12.1'),
-  ('kubeadm', '1.12.1'),
-  ('kubectl', '1.12.1'),
+  ('kubelet', '1.12.5'),
+  ('kubeadm', '1.12.5'),
+  ('kubectl', '1.12.5'),
   ('docker-ce', '18.06.2'),
   ('gitlab-runner', '11.7'),
   ('i965-va-driver', {'xenial': '1.7.0', 'bionic': '2.1.0'})


### PR DESCRIPTION
v1.12.2 fixes CVE-2018-1002105
v1.12.5 fixes CVE-2018-16875 (a Go vulnerability)