### PR TITLE
Ignore Ansible rule 405

### DIFF
--- a/molecule/no-role/molecule.yml
+++ b/molecule/no-role/molecule.yml
@@ -18,6 +18,10 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+    options:
+      x:
+        - ANSIBLE0016
+        - 405  # Remote package tasks should have a retry
 scenario:
   name: no-role
 verifier:


### PR DESCRIPTION
These rules are already ignored in the `default` tests, but not in the `no-role` tests. Disable them there, too.