### PR TITLE
Fix GitLab runner pinning

### DIFF
--- a/tasks/gitlab-runner.yml
+++ b/tasks/gitlab-runner.yml
@@ -9,14 +9,14 @@
     repo: "{{ gitlab_runner_repo }}"
     validate_certs: true
 
+- name: Pin GitLab package versions.
+  template:
+    src: apt-preferences-gitlab.j2
+    dest: /etc/apt/preferences.d/gitlab
+
 - name: Install GitLab runner {{ gitlab_runner_package }}
   apt:
     name: "{{ gitlab_runner_package }}={{ gitlab_runner_version }}"
     state: present
     update_cache: true
   register: installed_gitlab
-
-- name: Pin GitLab package versions.
-  template:
-    src: apt-preferences-gitlab.j2
-    dest: /etc/apt/preferences.d/gitlab

--- a/templates/apt-preferences-gitlab.j2
+++ b/templates/apt-preferences-gitlab.j2
@@ -1,3 +1,3 @@
-Package: gitlab_runner
+Package: {{ gitlab_runner_package }}
 Pin: version {{ gitlab_runner_version }}*
 Pin-Priority: 1000


### PR DESCRIPTION
The package name is `gitlab-runner`, not `gitlab_runner`. Also pin the package version _before_ installing the package (although not strictly required because we specify the package version when installing it).